### PR TITLE
Add optional buttontext

### DIFF
--- a/QNotifications/QNotification.py
+++ b/QNotifications/QNotification.py
@@ -14,8 +14,8 @@ __license__ = u"GPLv3"
 class MessageLabel(QtWidgets.QLabel):
 	""" Subclass of QLabel, which reimplements the resizeEvent() function. This
 	is necessary because otherwise the notifications take up too much vertical
-	space when texts they display become longer. This is because normally the height 
-	of a notification is calculated as the minimum height necessary for the text 
+	space when texts they display become longer. This is because normally the height
+	of a notification is calculated as the minimum height necessary for the text
 	when the widget is horizontally resized to its minimum. """
 
 	def resizeEvent(self, event):
@@ -30,7 +30,7 @@ class QNotification(QtWidgets.QWidget):
 	closeClicked = QtCore.pyqtSignal()
 	""" PyQt signal for click on the notification's close button. """
 
-	def __init__(self, message, category, *args, **kwargs):
+	def __init__(self, message, category, buttontext=None, *args, **kwargs):
 		"""Constructor
 
 		Parameters
@@ -38,7 +38,7 @@ class QNotification(QtWidgets.QWidget):
 		message : str
 			The message to show
 		category : {'primary', 'success', 'info', 'warning', 'danger'}
-			The type of notification. Adheres to bootstrap standard 
+			The type of notification. Adheres to bootstrap standard
 			classes which are {primary, success, info, warning, danger}
 		"""
 		super(QNotification, self).__init__(*args, **kwargs)
@@ -50,7 +50,7 @@ class QNotification(QtWidgets.QWidget):
 		self.setObjectName(category)
 		self.setLayout(QtWidgets.QHBoxLayout())
 		self.setContentsMargins(0,0,0,0)
-		# self.setSizePolicy(QtWidgets.QSizePolicy.Minimum, 
+		# self.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
 		# 	QtWidgets.QSizePolicy.Fixed)
 
 		# Create a message area
@@ -61,15 +61,20 @@ class QNotification(QtWidgets.QWidget):
 		# Create the layout
 		self.message_display = MessageLabel()
 		self.message_display.setObjectName("message")
-		self.message_display.setSizePolicy(QtWidgets.QSizePolicy.Minimum, 
+		self.message_display.setSizePolicy(QtWidgets.QSizePolicy.Minimum,
 			QtWidgets.QSizePolicy.Minimum)
 		self.message_display.setWordWrap(True)
 
 		# Create a button that can close notifications
-		close_button = QtWidgets.QPushButton(u"\u2715")
-		close_button.setObjectName("closeButton")
-		close_button.setFixedWidth(20)
+		if buttontext in (None, u''):
+			close_button = QtWidgets.QPushButton(u"\u2715")
+		else:
+			close_button = QtWidgets.QPushButton(buttontext)
+			close_button.setStyleSheet(u'text-decoration: underline;')
+		close_button.setSizePolicy(QtWidgets.QSizePolicy.Fixed,
+			QtWidgets.QSizePolicy.Fixed)
 		close_button.setFlat(True)
+		close_button.setObjectName("closeButton")
 		close_button.clicked.connect(self.closeClicked)
 
 		# Add everything together
@@ -84,7 +89,7 @@ class QNotification(QtWidgets.QWidget):
 
 		# Flag that is set if notification is being removed. This can be used to
 		# make sure that even though the notification has not been really removed
-		# yet (because it is for example in an fade out animation), it is in the 
+		# yet (because it is for example in an fade out animation), it is in the
 		# process of being removed
 		self.isBeingRemoved = False
 
@@ -96,13 +101,13 @@ class QNotification(QtWidgets.QWidget):
 		self.opacityEffect = QtWidgets.QGraphicsOpacityEffect(self)
 
 		# Fade in animation
-		self.fadeInAnimation = QtCore.QPropertyAnimation(self.opacityEffect, 
+		self.fadeInAnimation = QtCore.QPropertyAnimation(self.opacityEffect,
 			safe_encode("opacity"))
 		self.fadeInAnimation.setStartValue(0.0)
 		self.fadeInAnimation.setEndValue(1.0)
 
 		# Fade out animation
-		self.fadeOutAnimation = QtCore.QPropertyAnimation(self.opacityEffect, 
+		self.fadeOutAnimation = QtCore.QPropertyAnimation(self.opacityEffect,
 			safe_encode("opacity"))
 		self.fadeOutAnimation.setStartValue(1.0)
 		self.fadeOutAnimation.setEndValue(0.0)
@@ -119,7 +124,7 @@ class QNotification(QtWidgets.QWidget):
 
 	def fadeIn(self, duration):
 		""" Fades in the notification.
-	
+
 		Parameters
 		----------
 		duration : int
@@ -139,8 +144,8 @@ class QNotification(QtWidgets.QWidget):
 		self.fadeInAnimation.start()
 
 	def fadeOut(self, finishedCallback, duration):
-		""" Fades out the notification. 
-	
+		""" Fades out the notification.
+
 		Parameters
 		----------
 		finishedCallback : callable
@@ -167,8 +172,8 @@ class QNotification(QtWidgets.QWidget):
 		self.fadeOutAnimation.start()
 
 	def paintEvent(self, pe):
-		""" redefinition of paintEvent, do not call directly. 
-		Makes class QNotification available in style sheets. Interal Qt function. 
+		""" redefinition of paintEvent, do not call directly.
+		Makes class QNotification available in style sheets. Interal Qt function.
 		Should not be called directly. """
 		o = QtWidgets.QStyleOption()
 		o.initFrom(self)
@@ -193,7 +198,7 @@ class QNotification(QtWidgets.QWidget):
 
 	@category.setter
 	def category(self, value):
-		""" Sets the category of this notification. 
+		""" Sets the category of this notification.
 
 		Parameters
 		----------
@@ -211,4 +216,3 @@ class QNotification(QtWidgets.QWidget):
 			raise ValueError(u'{} not a valid value. '
 				'Should be one of').format(value, allowed_values)
 		self._category = value
-

--- a/QNotifications/QNotificationArea.py
+++ b/QNotifications/QNotificationArea.py
@@ -87,14 +87,14 @@ class QNotificationArea(QtWidgets.QWidget):
 
 		useGlobalCSS = kwargs.pop(u'useGlobalCSS', False)
 		super(QNotificationArea, self).__init__(*args, **kwargs)
-		
+
 		if not useGlobalCSS:
 			self.setStyleSheet(self.default_notification_styles)
-		
+
 		self.setParent(targetWidget)
 		self.targetWidget = targetWidget
 		self.setContentsMargins(0,0,0,0)
-		
+
 		notification_area_layout = QtWidgets.QVBoxLayout()
 		self.setLayout(notification_area_layout)
 
@@ -123,8 +123,8 @@ class QNotificationArea(QtWidgets.QWidget):
 
 	# Public functions
 	def setEntryEffect(self, effect, duration=250):
-		""" Sets the effect with which the notifications are to appear. 
-	
+		""" Sets the effect with which the notifications are to appear.
+
 		Parameters
 		----------
 		effect : {'fadeIn', None}
@@ -153,8 +153,8 @@ class QNotificationArea(QtWidgets.QWidget):
 		self.entryEffectDuration = duration
 
 	def setExitEffect(self, effect, duration=500):
-		""" Sets the effect with which the notifications are to disappear. 
-	
+		""" Sets the effect with which the notifications are to disappear.
+
 		Parameters
 		----------
 		effect : {'fadeOut', None}
@@ -183,10 +183,10 @@ class QNotificationArea(QtWidgets.QWidget):
 		self.exitEffectDuration = duration
 
 	# Events
-	@QtCore.pyqtSlot('QString', 'QString', int)
-	def display(self, message, category, timeout=5000):
-		""" Displays a notification. 
-	
+	@QtCore.pyqtSlot('QString', 'QString', int, 'QString')
+	def display(self, message, category, timeout=5000, buttontext=None):
+		""" Displays a notification.
+
 		Parameters
 		----------
 		message : str
@@ -205,7 +205,7 @@ class QNotificationArea(QtWidgets.QWidget):
 		"""
 
 		self.show()
-		notification = QNotification(message, category, self)
+		notification = QNotification(message, category, buttontext, self)
 		notification.closeClicked.connect(self.remove)
 		self.layout().addWidget(notification)
 		# Check for entry effects
@@ -217,13 +217,13 @@ class QNotificationArea(QtWidgets.QWidget):
 
 		self.adjustSize()
 		if not timeout is None and timeout > 0:
-			QtCore.QTimer.singleShot(timeout, 
+			QtCore.QTimer.singleShot(timeout,
 				lambda : self.remove(notification))
 
 	@QtCore.pyqtSlot()
 	def remove(self, notification = None):
 		""" Removes a notification.
-	
+
 		Parameters
 		----------
 		notification : QNotification (default: None)
@@ -266,17 +266,15 @@ class QNotificationArea(QtWidgets.QWidget):
 	def resizeEvent(self, event):
 		""" Internal QT function (do not call directly). """
 		self.target_resize_event(event)
-		newsize = event.size()		
+		newsize = event.size()
 		self.setFixedWidth(newsize.width())
 		self.adjustSize()
 
 	def paintEvent(self, pe):
-		""" Redefinition of paintEvent. 
-		Makes class QNotificationArea available in style sheets. 
+		""" Redefinition of paintEvent.
+		Makes class QNotificationArea available in style sheets.
 		Internal QT function (do not call directly) """
 		o = QtWidgets.QStyleOption()
 		o.initFrom(self)
 		p = QtGui.QPainter(self)
 		self.style().drawPrimitive(QtWidgets.QStyle.PE_Widget, o, p, self)
-	
-	

--- a/QNotifications/__init__.py
+++ b/QNotifications/__init__.py
@@ -17,10 +17,9 @@ GNU General Public License for more details.
 You should have received a copy of the GPLv3 License
 along with this module.>.
 """
-__version__ = "1.0.7"
+__version__ = "1.0.8"
 __author__ = "Daniel Schreij (dschreij@gmail.com)"
 
 # Do some base imports
 from QNotifications.QNotificationArea import QNotificationArea
 from QNotifications.QNotification import QNotification
-

--- a/example.py
+++ b/example.py
@@ -33,7 +33,7 @@ import sys
 
 class Example(QtCore.QObject):
 	""" Example showing off the notifications """
-	notify = QtCore.pyqtSignal(str,str,int)
+	notify = QtCore.pyqtSignal(str,str,int,str)
 
 	def __init__(self):
 		super(Example,self).__init__()
@@ -56,7 +56,7 @@ class Example(QtCore.QObject):
 		type_label = QtWidgets.QLabel("Notification type: ", display_widget)
 		self.type_dropdown = QtWidgets.QComboBox(display_widget)
 		self.type_dropdown.addItems(["primary", "success", "info", "warning", "danger"])
-		
+
 		# Notification duration
 		duration_label = QtWidgets.QLabel("Display duration: (ms)", display_widget)
 		self.message_duration = QtWidgets.QSpinBox(display_widget)
@@ -69,14 +69,14 @@ class Example(QtCore.QObject):
 		self.entry_dropdown.addItems(["None","fadeIn"])
 		try:
 			self.entry_dropdown.currentTextChanged.connect(self.__process_combo_change)
-		except AttributeError: 
+		except AttributeError:
 			self.entry_dropdown.editTextChanged.connect(self.__process_combo_change)
 		# Entry effect duration
 		self.entryduration_label = QtWidgets.QLabel("Effect duration: (ms)", display_widget)
 		self.entryduration = QtWidgets.QSpinBox(display_widget)
 		self.entryduration.setRange(100, 1000)
 		self.entryduration.setSingleStep(50)
-		# Exit effect 
+		# Exit effect
 		exiteffect_label = QtWidgets.QLabel("Exit effect: ", display_widget)
 		self.exit_dropdown = QtWidgets.QComboBox(display_widget)
 		self.exit_dropdown.addItems(["None","fadeOut"])
@@ -144,7 +144,7 @@ class Example(QtCore.QObject):
 			entry_effect = self.entry_dropdown.currentText()
 			exit_effect = self.exit_dropdown.currentText()
 			if entry_effect != "None":
-				self.notification_area.setEntryEffect(entry_effect, 
+				self.notification_area.setEntryEffect(entry_effect,
 					self.entryduration.value())
 			else:
 				self.notification_area.setEntryEffect(None)
@@ -153,7 +153,7 @@ class Example(QtCore.QObject):
 					self.exitduration.value())
 			else:
 				self.notification_area.setExitEffect(None)
-			self.notify.emit(textvalue, typevalue, duration)
+			self.notify.emit(textvalue, typevalue, duration, None)
 
 if __name__ == "__main__":
 	app = QtWidgets.QApplication(sys.argv)

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -2,7 +2,7 @@
 Source=python-qnotifications
 Package=python-qnotifications
 Debian-version=1
-Suite=wily
+Suite=xenial
 Copyright-File=copyright
 Build-Depends=python-qtpy, python-qt4
 Depends=python-qtpy, python-qt4


### PR DESCRIPTION
I added an optional buttontext keyword. If none is provided, a cross is shown like before. We discussed this before, and I'm aware that it goes against the Gnome HIG, but I still think we should add it. The reason is that OpenSesame now sends a ping to cogsci.nl when the Get Started tab is shown, and users should be aware of this, and of the possibility to disable it. By having them explicitly click on 'Got it!', instead of a cross, I think we reduce the chance of users unwittingly dismissing the message.
