### PR TITLE
Fix compatibility with qtpy >= 1.1.0

### DIFF
--- a/QNotifications/QNotification.py
+++ b/QNotifications/QNotification.py
@@ -30,7 +30,7 @@ class MessageLabel(QtWidgets.QLabel):
 class QNotification(QtWidgets.QWidget):
 	""" Class representing a single notification """
 
-	closeClicked = QtCore.pyqtSignal()
+	closeClicked = QtCore.Signal()
 	""" PyQt signal for click on the notification's close button. """
 
 	def __init__(self, message, category, timeout=None, buttontext=None, *args, **kwargs):

--- a/QNotifications/QNotificationArea.py
+++ b/QNotifications/QNotificationArea.py
@@ -211,8 +211,8 @@ class QNotificationArea(QtWidgets.QWidget):
 		self.exitEffectDuration = duration
 
 	# Events
-	@QtCore.pyqtSlot('QString', 'QString', int)
-	@QtCore.pyqtSlot('QString', 'QString', int, 'QString')
+	@QtCore.Slot('QString', 'QString', int)
+	@QtCore.Slot('QString', 'QString', int, 'QString')
 	def display(self, message, category, timeout=5000, buttontext=None):
 		""" Displays a notification.
 
@@ -267,7 +267,7 @@ class QNotificationArea(QtWidgets.QWidget):
 				lambda : self.remove(notification))
 
 
-	@QtCore.pyqtSlot()
+	@QtCore.Slot()
 	def remove(self, notification = None):
 		""" Removes a notification.
 

--- a/example.py
+++ b/example.py
@@ -33,7 +33,7 @@ import sys
 
 class Example(QtCore.QObject):
 	""" Example showing off the notifications """
-	notify = QtCore.pyqtSignal(['QString', 'QString', int],
+	notify = QtCore.Signal(['QString', 'QString', int],
 		['QString', 'QString', int, 'QString'])
 
 	def __init__(self):
@@ -173,7 +173,7 @@ class Example(QtCore.QObject):
 if __name__ == "__main__":
 	app = QtWidgets.QApplication(sys.argv)
 
-	print(QtCore.QT_VERSION_STR)
+	print(QtCore.PYQT_VERSION_STR)
 
 	# Enable High DPI display with PyQt5
 	if hasattr(QtCore.Qt, 'AA_UseHighDpiPixmaps'):


### PR DESCRIPTION
The following replacements have been done automatically:
- QtCore.pyqtSignal -> QtCore.Signal
- QtCore.pyqtSlot -> QtCore.Slot
- QtCore.QT_VERSION_STR -> QtCore.PYQT_VERSION_STR
  versions are not identical but both indicate whether Qt 4 or 5 is used
