### PR TITLE
Fix deb packaging for stdeb3

### DIFF
--- a/QNotifications/__init__.py
+++ b/QNotifications/__init__.py
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GPLv3 License
 along with this module.>.
 """
-__version__ = "2.0.3"
+__version__ = "2.0.4a2"
 __author__ = "Daniel Schreij (dschreij@gmail.com)"
 
 # Do some base imports

--- a/setup.py
+++ b/setup.py
@@ -18,11 +18,12 @@ You should have received a copy of the GNU General Public License
 along with QNotifications.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import sys
 from setuptools import setup, find_packages
 import QNotifications
 
 setup(
-	name='python-qnotifications',
+	name=u'qnotifications' if u'bdist_deb' in sys.argv else 'python-qnotifications',
 	version=QNotifications.__version__,
 	description='Pretty in-app notifications for PyQt',
 	author='Daniel Schreij',

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,8 +1,9 @@
 [DEFAULT]
-Source=python-qnotifications
+Source=qnotifications
 Package=python-qnotifications
 Debian-version=1
-Suite=xenial
+Suite=bionic
 Copyright-File=copyright
-Build-Depends=python-qtpy, python-qt4
-Depends=python-qtpy, python-qt4
+Build-Depends=python-qtpy, python-pyqt5, python3-qtpy, python3-pyqt5
+Depends=python-qtpy, python-pyqt5
+Depends3=python3-qtpy, python3-pyqt5


### PR DESCRIPTION
This is a slight tweak to the packaging system for Ubuntu, using stdeb3. This now allows packaging for Python 3 and Python 2 packages. Right now the packages live in https://launchpad.net/~smathot/+archive/ubuntu/rapunzel/.