### PR TITLE
Don't show notification while mouse hovers over notification area

### DIFF
--- a/QNotifications/QNotificationArea.py
+++ b/QNotifications/QNotificationArea.py
@@ -266,17 +266,16 @@ class QNotificationArea(QtWidgets.QWidget):
 		return geom.contains(cursor_pos)
 
 	def _show_notification(self, notification):
-		if not self.isVisible():
-			self.show()
-			self.raise_()
-		self.layout().addWidget(notification)
 		if self._cursor_in_area():
-			self.layout().removeWidget(notification)
 			QtCore.QTimer.singleShot(
 				1000,
 				lambda : self._show_notification(notification)
 			)
 			return
+		if not self.isVisible():
+			self.show()
+			self.raise_()
+		self.layout().addWidget(notification)
 		# Check for entry effects
 		if not self.entryEffect is None:
 			if self.entryEffect == u"fadeIn":

--- a/QNotifications/__init__.py
+++ b/QNotifications/__init__.py
@@ -17,7 +17,7 @@ GNU General Public License for more details.
 You should have received a copy of the GPLv3 License
 along with this module.>.
 """
-__version__ = "2.0.5"
+__version__ = "2.0.6"
 __author__ = "Daniel Schreij (dschreij@gmail.com)"
 
 # Do some base imports


### PR DESCRIPTION
A quick shot at fixing the annoying issue #14. Can you test this and, if all is ok, do a quick release?